### PR TITLE
Add support for the `apns-push-type` header

### DIFF
--- a/src/main/java/com/eatthepath/pushy/console/NotificationTypeListCell.java
+++ b/src/main/java/com/eatthepath/pushy/console/NotificationTypeListCell.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021 Jon Chambers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.eatthepath.pushy.console;
+
+import com.eatthepath.pushy.apns.PushType;
+import javafx.scene.control.ListCell;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+public class NotificationTypeListCell extends ListCell<PushType> {
+
+    @Override
+    public void updateItem(final PushType pushType, final boolean empty) {
+        super.updateItem(pushType, empty);
+
+        if (!empty) {
+            final ResourceBundle resourceBundle = PushyConsoleApplication.RESOURCE_BUNDLE;
+            setText(resourceBundle.getString("notification-type." + pushType.name().toLowerCase(Locale.US)));
+        } else {
+            setText(null);
+        }
+    }
+}

--- a/src/main/java/com/eatthepath/pushy/console/PushyConsoleController.java
+++ b/src/main/java/com/eatthepath/pushy/console/PushyConsoleController.java
@@ -35,6 +35,7 @@ import javafx.scene.control.*;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.text.MessageFormat;
+import java.util.Locale;
 import java.util.ResourceBundle;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -59,6 +60,7 @@ public class PushyConsoleController {
     @FXML private TableColumn<PushNotificationResponse<ApnsPushNotification>, String> notificationResultPayloadColumn;
     @FXML private TableColumn<PushNotificationResponse<ApnsPushNotification>, String> notificationResultCollapseIdColumn;
     @FXML private TableColumn<PushNotificationResponse<ApnsPushNotification>, String> notificationResultPriorityColumn;
+    @FXML private TableColumn<PushNotificationResponse<ApnsPushNotification>, String> notificationResultTypeColumn;
 
     @FXML private TableColumn<PushNotificationResponse<ApnsPushNotification>, String> notificationResultStatusColumn;
     @FXML private TableColumn<PushNotificationResponse<ApnsPushNotification>, String> notificationResultDetailsColumn;
@@ -92,6 +94,9 @@ public class PushyConsoleController {
                 cellDataFeatures.getValue().getPushNotification().getPriority() == DeliveryPriority.IMMEDIATE ?
                         resources.getString("delivery-priority.immediate") :
                         resources.getString("delivery-priority.conserve-power")));
+
+        notificationResultTypeColumn.setCellValueFactory(cellDataFeatures -> new ReadOnlyStringWrapper(
+                resources.getString("notification-type." + cellDataFeatures.getValue().getPushNotification().getPushType().name().toLowerCase(Locale.US))));
 
         notificationResultStatusColumn.setCellValueFactory(cellDataFeatures -> new ReadOnlyStringWrapper(
                 cellDataFeatures.getValue().isAccepted() ?

--- a/src/main/resources/com/eatthepath/pushy/console/compose-notification.fxml
+++ b/src/main/resources/com/eatthepath/pushy/console/compose-notification.fxml
@@ -37,7 +37,7 @@
   ~ THE SOFTWARE.
   -->
 
-<GridPane hgap="10.0" vgap="8.0" xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.eatthepath.pushy.console.ComposeNotificationController">
+<GridPane hgap="10.0" vgap="8.0" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.eatthepath.pushy.console.ComposeNotificationController">
   <columnConstraints>
     <ColumnConstraints halignment="RIGHT" hgrow="NEVER" maxWidth="-Infinity" minWidth="-Infinity" />
     <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
@@ -45,8 +45,10 @@
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
   </columnConstraints>
   <rowConstraints>
+    <RowConstraints />
     <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-    <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+      <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+      <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
       <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
       <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
       <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
@@ -55,39 +57,41 @@
       <RowConstraints minHeight="10.0" valignment="TOP" />
   </rowConstraints>
    <children>
-      <Label text="%fxml.apns-server.label" />
-      <HBox alignment="CENTER_LEFT" spacing="10.0" GridPane.columnIndex="1" GridPane.columnSpan="2147483647">
+      <Label text="%fxml.apns-server.label" GridPane.rowIndex="1" />
+      <HBox alignment="CENTER_LEFT" spacing="10.0" GridPane.columnIndex="1" GridPane.columnSpan="2147483647" GridPane.rowIndex="1">
          <children>
             <ComboBox fx:id="apnsServerComboBox" maxWidth="1.7976931348623157E308" prefWidth="270.0" GridPane.columnIndex="1" HBox.hgrow="ALWAYS" />
             <Label maxWidth="-Infinity" minWidth="-Infinity" text="%fxml.port.label" HBox.hgrow="NEVER" />
             <ComboBox fx:id="apnsPortComboBox" minWidth="-Infinity" prefWidth="80.0" HBox.hgrow="NEVER" />
          </children>
       </HBox>
-      <Label text="%fxml.credentials.label" GridPane.rowIndex="1" />
-      <HBox alignment="CENTER_LEFT" spacing="10.0" GridPane.columnIndex="1" GridPane.columnSpan="2147483647" GridPane.rowIndex="1">
+      <Label text="%fxml.credentials.label" GridPane.rowIndex="2" />
+      <HBox alignment="CENTER_LEFT" spacing="10.0" GridPane.columnIndex="1" GridPane.columnSpan="2147483647" GridPane.rowIndex="2">
          <children>
             <TextField fx:id="apnsCredentialFileTextField" editable="false" maxWidth="1.7976931348623157E308" GridPane.columnIndex="1" GridPane.rowIndex="1" HBox.hgrow="ALWAYS" />
             <Button maxWidth="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#handleBrowseButtonAction" text="%fxml.browse.label" HBox.hgrow="NEVER" />
          </children>
       </HBox>
-      <Label fx:id="keyIdLabel" disable="true" text="%fxml.key-id.label" GridPane.rowIndex="2" />
-      <ComboBox fx:id="keyIdComboBox" disable="true" editable="true" maxWidth="1.7976931348623157E308" GridPane.columnIndex="1" GridPane.hgrow="ALWAYS" GridPane.rowIndex="2" />
-      <Label fx:id="teamIdLabel" disable="true" text="%fxml.team-id.label" GridPane.columnIndex="2" GridPane.rowIndex="2" />
-      <ComboBox fx:id="teamIdComboBox" disable="true" editable="true" maxWidth="1.7976931348623157E308" GridPane.columnIndex="3" GridPane.hgrow="ALWAYS" GridPane.rowIndex="2" />
-      <Separator prefWidth="200.0" GridPane.columnSpan="2147483647" GridPane.rowIndex="3" />
-      <Label text="%fxml.topic.label" GridPane.rowIndex="4" />
-      <ComboBox fx:id="topicComboBox" editable="true" maxWidth="1.7976931348623157E308" GridPane.columnIndex="1" GridPane.columnSpan="2147483647" GridPane.rowIndex="4" />
-      <Label text="%fxml.token.label" GridPane.rowIndex="5" />
-      <ComboBox fx:id="deviceTokenComboBox" editable="true" maxWidth="1.7976931348623157E308" GridPane.columnIndex="1" GridPane.columnSpan="2147483647" GridPane.rowIndex="5" />
-      <Label text="%fxml.collapse-id.label" GridPane.rowIndex="6" />
-      <ComboBox fx:id="collapseIdComboBox" editable="true" maxWidth="1.7976931348623157E308" GridPane.columnIndex="1" GridPane.hgrow="ALWAYS" GridPane.rowIndex="6" />
-      <Label text="%fxml.priority.label" GridPane.columnIndex="2" GridPane.rowIndex="6" />
-      <ComboBox fx:id="deliveryPriorityComboBox" maxWidth="1.7976931348623157E308" GridPane.columnIndex="3" GridPane.hgrow="ALWAYS" GridPane.rowIndex="6" />
-      <Label text="%fxml.payload.label" GridPane.rowIndex="7">
+      <Label fx:id="keyIdLabel" disable="true" text="%fxml.key-id.label" GridPane.rowIndex="3" />
+      <ComboBox fx:id="keyIdComboBox" disable="true" editable="true" maxWidth="1.7976931348623157E308" GridPane.columnIndex="1" GridPane.hgrow="ALWAYS" GridPane.rowIndex="3" />
+      <Label fx:id="teamIdLabel" disable="true" text="%fxml.team-id.label" GridPane.columnIndex="2" GridPane.rowIndex="3" />
+      <ComboBox fx:id="teamIdComboBox" disable="true" editable="true" maxWidth="1.7976931348623157E308" GridPane.columnIndex="3" GridPane.hgrow="ALWAYS" GridPane.rowIndex="3" />
+      <Separator prefWidth="200.0" GridPane.columnSpan="2147483647" GridPane.rowIndex="4" />
+      <Label text="%fxml.topic.label" GridPane.rowIndex="5" />
+      <ComboBox fx:id="topicComboBox" editable="true" maxWidth="1.7976931348623157E308" GridPane.columnIndex="1" GridPane.columnSpan="2147483647" GridPane.rowIndex="5" />
+      <Label text="%fxml.token.label" GridPane.rowIndex="6" />
+      <ComboBox fx:id="deviceTokenComboBox" editable="true" maxWidth="1.7976931348623157E308" GridPane.columnIndex="1" GridPane.columnSpan="2147483647" GridPane.rowIndex="6" />
+      <Label text="%fxml.collapse-id.label" GridPane.rowIndex="7" />
+      <ComboBox fx:id="collapseIdComboBox" editable="true" maxWidth="1.7976931348623157E308" GridPane.columnIndex="1" GridPane.hgrow="ALWAYS" GridPane.rowIndex="7" />
+      <Label text="%fxml.priority.label" GridPane.rowIndex="8" />
+      <ComboBox fx:id="deliveryPriorityComboBox" maxWidth="1.7976931348623157E308" GridPane.columnIndex="1" GridPane.hgrow="ALWAYS" GridPane.rowIndex="8" />
+      <Label text="%fxml.type.label" GridPane.columnIndex="2" GridPane.rowIndex="8" />
+      <ComboBox fx:id="notificationTypeComboBox" maxWidth="1.7976931348623157E308" GridPane.columnIndex="3" GridPane.hgrow="ALWAYS" GridPane.rowIndex="8" />
+      <Label text="%fxml.payload.label" GridPane.rowIndex="9">
          <GridPane.margin>
             <Insets top="5.0" />
          </GridPane.margin></Label>
-      <VBox spacing="8.0" GridPane.columnIndex="1" GridPane.columnSpan="2147483647" GridPane.rowIndex="7">
+      <VBox spacing="8.0" GridPane.columnIndex="1" GridPane.columnSpan="2147483647" GridPane.rowIndex="9">
          <children>
             <MenuButton fx:id="recentPayloadsMenuButton" disable="true" mnemonicParsing="false" text="%fxml.recent-payloads.label" />
             <TextArea fx:id="payloadTextArea" prefRowCount="6">

--- a/src/main/resources/com/eatthepath/pushy/console/main.fxml
+++ b/src/main/resources/com/eatthepath/pushy/console/main.fxml
@@ -29,7 +29,7 @@
   ~ THE SOFTWARE.
   -->
 
-<VBox maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefWidth="600.0" spacing="10.0" xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.eatthepath.pushy.console.PushyConsoleController">
+<VBox maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefWidth="600.0" spacing="10.0" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.eatthepath.pushy.console.PushyConsoleController">
    <children>
       <fx:include fx:id="composeNotification" source="compose-notification.fxml" />
       <AnchorPane VBox.vgrow="NEVER">
@@ -49,6 +49,7 @@
                   <TableColumn fx:id="notificationResultPayloadColumn" editable="false" prefWidth="100.0" sortable="false" text="%fxml.payload.label" />
                   <TableColumn fx:id="notificationResultCollapseIdColumn" editable="false" prefWidth="100.0" sortable="false" text="%fxml.collapse-id.label" />
                   <TableColumn fx:id="notificationResultPriorityColumn" editable="false" prefWidth="100.0" sortable="false" text="%fxml.priority.label" />
+                  <TableColumn fx:id="notificationResultTypeColumn" prefWidth="75.0" text="%fxml.type.label" />
                </columns></TableColumn>
           <TableColumn prefWidth="-1.0" text="%fxml.response.label">
                <columns>

--- a/src/main/resources/com/eatthepath/pushy/console/pushy-console_en.properties
+++ b/src/main/resources/com/eatthepath/pushy/console/pushy-console_en.properties
@@ -39,6 +39,13 @@ certificate-password-dialog.prompt=Password
 delivery-priority.immediate=Immediate
 delivery-priority.conserve-power=Conserve power
 
+notification-type.alert=Alert
+notification-type.background=Background
+notification-type.voip=VoIP
+notification-type.complication=Complication
+notification-type.fileprovider=File Provider
+notification-type.mdm=Mobile Device Management (MDM)
+
 notification-result.placeholder=No notifications sent
 notification-result.details.accepted=n/a
 notification-result.details.expiration={0} ({1,date,yyyy-MM-dd} {1,time,HH:mm:ss})
@@ -62,6 +69,7 @@ fxml.topic.label=Topic
 fxml.token.label=Device token
 fxml.collapse-id.label=Collapse ID
 fxml.priority.label=Priority
+fxml.type.label=Notification type
 fxml.recent-payloads.label=Recent payloads
 fxml.payload.label=Payload
 fxml.send.label=Send notification


### PR DESCRIPTION
This change adds support for the `apns-push-type` header via a "notification type" dropdown.

<img width="712" alt="notification-type" src="https://user-images.githubusercontent.com/31352/120125806-1eb7b100-c188-11eb-8c9f-6d87cb60b6f0.png">