### PR TITLE
Add docker setup + correct some typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,10 @@ hs_err_pid*
 
 # Metadata, backup files, and other detritus
 .DS_Store
+
+# Temporary files
+*.swp
+
+# Secrets that the user might add
+*.pem
+*.p12

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+## Start from an official maven image
+# FROM maven:3-openjdk-11-slim  # Version issue
+# FROM maven:3-openjdk-18  # No method to install X11?
+# FROM maven:3-jdk-11  # Unsupported major.minor version 61.0
+# FROM maven:3-jdk-11  # Unsupported major.minor version 61.0
+FROM maven:3.8.6-ibm-semeru-17-focal
+
+
+LABEL maintainer="MDW <MDW@private.fr>"
+
+## Set environment variables
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+
+
+RUN apt-get update && apt-get install -y --no-install-recommends openjfx && rm -rf /var/lib/apt/lists/*
+
+# && mvn clean install && DISPLAY=localhost:0.0
+
+# Not on Debian: firefox firefox-geckodriver
+
+COPY pom.xml /tmp/pom.xml
+RUN mvn -B -f /tmp/pom.xml -s /usr/share/maven/ref/settings-docker.xml dependency:resolve
+# RUN mvn -B -f /tmp/pom.xml -s /usr/share/maven/ref/settings-docker.xml javafx:resolve
+
+# RUN mvn -B -f /tmp/pom.xml -s /usr/share/maven/ref/settings-docker.xml dependency:resolve
+# RUN mvn -B -f /tmp/pom.xml -s /usr/share/maven/ref/settings-docker.xml dependency:resolve
+

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Before you can start sending push notifications, you'll need to follow the instr
 Pushy Console supports both certificate-based and token-based authentication with the APNs server. Either is just fine from Pushy Console's perspective, and you can have multiple certificates and signing keys in play elsewhere. From a practical perspective:
 
 - Certificates expire after a year, and can only be used for a specific set of topics associated with a single app. You'll usually need a password to "unlock" a certificate.
-- Signing keys never expire, and can be used for all topics associated with your developer account. You don't need a pasword to use signing keys, but will need to know they key ID and your Apple Developer Team ID.
+- Signing keys never expire, and can be used for all topics associated with your developer account. You don't need a password to use signing keys, but will need to know they key ID and your Apple Developer Team ID.
 
 You can choose a credentials file by clicking the "browse" button next to the "credentials" field in Pushy Console. If you choose a certificate, you'll be prompted for a password. If you choose a signing key, you'll need to provide a key ID and team ID.
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,22 @@
+---
+services:
+  # Base image
+  pushy-console-base:
+    build:
+      context: .
+      args:
+        - --rm
+      dockerfile: ./Dockerfile
+    working_dir: /root/workdir
+    environment:
+      DISPLAY: host.docker.internal:0.0
+      NO_AT_BRIDGE: 1
+    volumes:
+      - .:/root/workdir
+
+  # Run this target in Docker using `docker compose pushy-console`
+  # You need to run an XServer on your host - on windows you can use `VcXsvr`
+  pushy-console:
+    extends: pushy-console-base
+    command: mvn -s /usr/share/maven/ref/settings-docker.xml javafx:run
+    # command: bash  # can be used to lauch interactive shell

--- a/src/main/java/com/eatthepath/pushy/console/ComposeNotificationController.java
+++ b/src/main/java/com/eatthepath/pushy/console/ComposeNotificationController.java
@@ -415,7 +415,7 @@ public class ComposeNotificationController {
                 }
             });
 
-            // Also set the psuedo class immediately based on the control's current state
+            // Also set the pseudo class immediately based on the control's current state
             comboBox.pseudoClassStateChanged(BLANK_PSEUDO_CLASS, StringUtils.isBlank(comboBox.getValue()));
         }
     }
@@ -431,7 +431,7 @@ public class ComposeNotificationController {
                 }
             });
 
-            // Also set the psuedo class immediately based on the control's current state
+            // Also set the pseudo class immediately based on the control's current state
             textInputControl.pseudoClassStateChanged(BLANK_PSEUDO_CLASS, StringUtils.isBlank(textInputControl.getText()));
         }
     }

--- a/src/test/script/openssl-custom.cnf
+++ b/src/test/script/openssl-custom.cnf
@@ -44,7 +44,7 @@ certs		= $dir/certs		# Where the issued certs are kept
 crl_dir		= $dir/crl		# Where the issued crl are kept
 database	= $dir/index.txt	# database index file.
 #unique_subject	= no			# Set to 'no' to allow creation of
-					# several ctificates with same subject.
+					# several certificates with same subject.
 new_certs_dir	= $dir/newcerts		# default place for new certs.
 
 certificate	= $dir/cacert.pem 	# The CA certificate
@@ -55,7 +55,7 @@ crl		= $dir/crl.pem 		# The current CRL
 private_key	= $dir/private/cakey.pem# The private key
 RANDFILE	= $dir/private/.rand	# private random number file
 
-x509_extensions	= usr_cert		# The extentions to add to the cert
+x509_extensions	= usr_cert		# The extensions to add to the cert
 
 # Comment out the following two lines for the "traditional"
 # (and highly broken) format.
@@ -107,7 +107,7 @@ default_bits		= 1024
 default_keyfile 	= privkey.pem
 distinguished_name	= req_distinguished_name
 attributes		= req_attributes
-x509_extensions	= v3_ca	# The extentions to add to the self signed cert
+x509_extensions	= v3_ca	# The extensions to add to the self signed cert
 
 # Passwords for private keys if not present they will be prompted for
 # input_password = secret


### PR DESCRIPTION
This add docker configuration files so that essentially
```docker compose run pushy-console```
and a local XServer is all that is needed to run the application.

Also fixed some typos identified with codespell.