### PR TITLE
feat(PushType): Add support for Live Activity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.eatthepath</groupId>
             <artifactId>pushy</artifactId>
-            <version>0.15.1</version>
+            <version>0.15.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/com/eatthepath/pushy/console/ComposeNotificationController.java
+++ b/src/main/java/com/eatthepath/pushy/console/ComposeNotificationController.java
@@ -183,7 +183,8 @@ public class ComposeNotificationController {
                 PushType.COMPLICATION,
                 PushType.FILEPROVIDER,
                 PushType.VOIP,
-                PushType.MDM
+                PushType.MDM,
+                PushType.LIVE_ACTIVITY
         ));
 
         try {

--- a/src/main/resources/com/eatthepath/pushy/console/pushy-console_en.properties
+++ b/src/main/resources/com/eatthepath/pushy/console/pushy-console_en.properties
@@ -45,6 +45,7 @@ notification-type.voip=VoIP
 notification-type.complication=Complication
 notification-type.fileprovider=File Provider
 notification-type.mdm=Mobile Device Management (MDM)
+notification-type.live_activity=Live Activity
 
 notification-result.placeholder=No notifications sent
 notification-result.details.accepted=n/a


### PR DESCRIPTION
This PR adds support for sending pushes for Live Activity in the pushy console.
Changes:
* Bump Pushy version to `0.15.2`
* Update PushType to support LiveActivity

## Notes
I have tested it for sending push to live activity and its working.